### PR TITLE
Public API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Once you have complete the above guide, continue to the steps below.
 
 [todo]: <Deploy and update the link below>
 
-[Deployed API Spec](https://UPDATEME)
+[Deployed API Spec](https://team-dev-api.nymo.xyz/api-docs)
 
 The API Spec is hosted by the server itself (i.e. this project), and the view/page is generated automatically by the SwaggerUI libraryi.
 


### PR DESCRIPTION
The OpenAPI spec has been fixed, so now it points to the public backend instead of `localhost:4000`

Try it yourself: [https://team-dev-api.nymo.xyz/api-docs](https://team-dev-api.nymo.xyz/api-docs)